### PR TITLE
Updating mbed-os to mbed-os-5.2.x

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0712b8adf6bbc7eb796d5dac26f95d79d40745ef
+https://github.com/ARMmbed/mbed-os/#a7a53b7b6ce630aafa75708b1cf5b2e1125a0321


### PR DESCRIPTION
Updating mbed-os to mbed-os-5.2.x.
This new version of mbed-os updates the BLE stack for Beetle boards.
@fvincenzo 
